### PR TITLE
remove deprecation error

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -7,7 +7,7 @@ if(process.env.MONGODB_URI) {
    
 }else {
 
-    mongoose.connect('mongodb://localhost/user-login-system', function(err){ //db = 'mongodb://localhost/yourdb'
+    mongoose.connect('mongodb://localhost/user-login-system',{ useNewUrlParser: true }, function(err){ //db = 'mongodb://localhost/yourdb'
         if(err){
             console.log(err);
         }else {


### PR DESCRIPTION
(node:32590) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
events.js:137
      throw er; // Unhandled 'error' event
      ^